### PR TITLE
Shorter event handlers

### DIFF
--- a/packages/template-compiler/src/index.ts
+++ b/packages/template-compiler/src/index.ts
@@ -53,6 +53,9 @@ export interface CompileOptions {
     /** Do not import components which were detected as unused */
     removeUnusedImports?: boolean;
 
+    /** URI for referencing component’s JS definition */
+    definition?: string;
+
     /** Called with warning messages */
     warn?(msg: string, pos?: number): void;
 }

--- a/packages/template-compiler/src/index.ts
+++ b/packages/template-compiler/src/index.ts
@@ -33,6 +33,12 @@ export interface CompileOptions {
     cssScope?: string;
 
     /**
+     * Mangle symbol names, used for scope variables. If enabled, outputs shorter
+     * but more cryptic variable names
+     */
+    mangleNames?: boolean;
+
+    /**
      * List of supported helpers. Key is an URL of module and value is a list of
      * available (exported) functions in this module
      */

--- a/packages/template-compiler/src/lib/CompileState.ts
+++ b/packages/template-compiler/src/lib/CompileState.ts
@@ -165,7 +165,7 @@ export default class CompileState {
         const { prefix = '', suffix = '' } = this.options;
         const globalSuffix = nameToJS(this.options.component || '', true) + suffix;
         this.globalSymbol = createSymbolGenerator(prefix, num => globalSuffix + num.toString(36));
-        this.scopeSymbol = createSymbolGenerator(prefix, num => suffix + num.toString(36));
+        this.scopeSymbol = createSymbolGenerator(prefix, num => suffix + num.toString(36), this.options.mangleNames);
     }
 
     /**

--- a/packages/template-compiler/src/lib/CompileState.ts
+++ b/packages/template-compiler/src/lib/CompileState.ts
@@ -26,7 +26,8 @@ export const defaultOptions: CompileOptions = {
     prefix: '',
     suffix: '$',
     module: 'endorphin',
-    component: ''
+    component: '',
+    definition: '%definition'
 };
 
 export default class CompileState {
@@ -106,6 +107,9 @@ export default class CompileState {
 
     /** List of symbols used for store access in template */
     usedStore: Set<string> = new Set();
+
+    /** List of component definition symbols used in runtime */
+    usedDefinition: Set<string> = new Set();
 
     /** Context of currently rendered block */
     blockContext?: BlockContext;

--- a/packages/template-compiler/src/lib/SymbolGenerator.ts
+++ b/packages/template-compiler/src/lib/SymbolGenerator.ts
@@ -8,18 +8,24 @@ const numGenerator: SymbolPartGenerator = num => num.toString(36);
  */
 export default function createSymbolGenerator(
         prefix: string | SymbolPartGenerator = '',
-        suffix: string | SymbolPartGenerator = numGenerator): SymbolGenerator {
+        suffix: string | SymbolPartGenerator = numGenerator,
+        mangle?: boolean): SymbolGenerator {
     const symbols: { [prefix: string]: number } = {};
 
     return name => {
-        if (name in symbols) {
-            symbols[name]++;
+        const base = mangle ? '' : name;
+        if (base in symbols) {
+            symbols[base]++;
         } else {
-            symbols[name] = 0;
+            symbols[base] = 0;
         }
 
-        const num = symbols[name];
-        return getPart(num, prefix) + name + getPart(num, suffix);
+        const num = symbols[base];
+        if (mangle) {
+            return `_${num.toString(36)}`;
+        }
+
+        return getPart(num, prefix) + base + getPart(num, suffix);
     };
 }
 

--- a/packages/template-compiler/src/template.ts
+++ b/packages/template-compiler/src/template.ts
@@ -82,7 +82,7 @@ export default function generateTemplate(ast: ENDProgram, options?: CompileOptio
 
     // Output scripts
     ast.scripts.forEach(() => {
-        body.push(sn(`export * from "${state.options.definition}"};`));
+        body.push(sn(`export * from "${state.options.definition}";`));
     });
 
     body.push('\n', template);

--- a/packages/template-compiler/src/visitors/expression.ts
+++ b/packages/template-compiler/src/visitors/expression.ts
@@ -19,7 +19,7 @@ export default {
             return state.helper(node.name);
         }
 
-        if (node.context && node.context !== 'argument') {
+        if (node.context && node.context !== 'argument' && node.context !== 'definition') {
             const prefix = next({
                 type: 'ENDGetterPrefix',
                 context: node.context
@@ -31,6 +31,10 @@ export default {
             }
 
             return sn([prefix, propGetter(node.name)], node, node.raw);
+        }
+
+        if (node.context === 'definition') {
+            state.usedDefinition.add(node.name);
         }
 
         return sn(node.name, node, node.name);

--- a/packages/template-compiler/test/fixtures/scripts/script1.js
+++ b/packages/template-compiler/test/fixtures/scripts/script1.js
@@ -1,5 +1,9 @@
 import { appendChild, elemWithText } from "endorphin";
-export * from "%definition";
+
+export function willRender(component) {
+	console.log('rendered', component.nodeName);
+}
+
 
 export default function template$0(host) {
 	const target$0 = host.componentView;

--- a/packages/template-compiler/test/fixtures/scripts/script1.js
+++ b/packages/template-compiler/test/fixtures/scripts/script1.js
@@ -1,9 +1,5 @@
 import { appendChild, elemWithText } from "endorphin";
-
-export function willRender(component) {
-	console.log('rendered', component.nodeName);
-}
-
+export * from "%definition";
 
 export default function template$0(host) {
 	const target$0 = host.componentView;

--- a/packages/template-compiler/test/fixtures/scripts/script2.js
+++ b/packages/template-compiler/test/fixtures/scripts/script2.js
@@ -1,5 +1,5 @@
 import { appendChild, elemWithText } from "endorphin";
-export * from "%definition";
+export * from "./script.js";
 
 export default function template$0(host) {
 	const target$0 = host.componentView;

--- a/packages/template-compiler/test/fixtures/scripts/script2.js
+++ b/packages/template-compiler/test/fixtures/scripts/script2.js
@@ -1,5 +1,5 @@
 import { appendChild, elemWithText } from "endorphin";
-export * from "./script.js";
+export * from "%definition";
 
 export default function template$0(host) {
 	const target$0 = host.componentView;

--- a/packages/template-compiler/test/fixtures/templates/animate-function.js
+++ b/packages/template-compiler/test/fixtures/templates/animate-function.js
@@ -1,6 +1,7 @@
 import { animate, createComponent, createInjector, domRemove, elemWithText, insert, mountBlock, mountComponent, unmountBlock, unmountComponent, updateBlock } from "endorphin";
 import * as InnerComponent from "./inner-component.html";
 import * as OuterComponent from "./outer-component.html";
+import { collapse, expand } from "%definition";
 
 function animatedOuterComponent$0(host, injector, scope) {
 	const outerComponent$0 = scope.outerComponent$0 = insert(injector, createComponent("outer-component", OuterComponent, host));
@@ -19,14 +20,14 @@ function animatedOuterComponent$0Unmount(scope) {
 
 function ifBody$0(host, injector, scope) {
 	!scope.outerComponent$0 && animatedOuterComponent$0(host, injector, scope);
-	animate(scope.outerComponent$0, host.componentModel.definition.expand(scope.outerComponent$0));
+	animate(scope.outerComponent$0, expand(scope.outerComponent$0));
 }
 
 ifBody$0.dispose = ifBody$0Unmount;
 
 function ifBody$0Unmount(scope, host) {
 	const { outerComponent$0 } = scope;
-	animate(outerComponent$0, host.componentModel.definition.collapse(outerComponent$0, { duration: host.state.duration }), () => animatedOuterComponent$0Unmount(scope, host));
+	animate(outerComponent$0, collapse(outerComponent$0, { duration: host.state.duration }), () => animatedOuterComponent$0Unmount(scope, host));
 }
 
 function ifEntry$0(host) {

--- a/packages/template-compiler/test/fixtures/templates/animate-function.js
+++ b/packages/template-compiler/test/fixtures/templates/animate-function.js
@@ -1,7 +1,10 @@
 import { animate, createComponent, createInjector, domRemove, elemWithText, insert, mountBlock, mountComponent, unmountBlock, unmountComponent, updateBlock } from "endorphin";
 import * as InnerComponent from "./inner-component.html";
 import * as OuterComponent from "./outer-component.html";
-import { collapse, expand } from "%definition";
+
+export function collapse() {};
+export function expand() {};
+
 
 function animatedOuterComponent$0(host, injector, scope) {
 	const outerComponent$0 = scope.outerComponent$0 = insert(injector, createComponent("outer-component", OuterComponent, host));

--- a/packages/template-compiler/test/fixtures/templates/events-assignment.js
+++ b/packages/template-compiler/test/fixtures/templates/events-assignment.js
@@ -1,20 +1,20 @@
 import { addEvent, appendChild, elem, removeEvent } from "endorphin";
 
-function onEvt1$0(evt) {
-	this.host.setState({ count: this.host.state.count + 1 });
+function onEvt1$0(host, evt) {
+	host.setState({ count: host.state.count + 1 });
 }
 
-function onEvt2$0(evt) {
-	this.host.setState({ count: this.host.state.count + 2 });
+function onEvt2$0(host, evt) {
+	host.setState({ count: host.state.count + 2 });
 }
 
-function onEvt3$0(evt) {
-	this.host.store.set({ s: !this.host.state.enabled });
+function onEvt3$0(host, evt) {
+	host.store.set({ s: !host.state.enabled });
 }
 
-function onEvt4$0(e) {
-	this.host.setState({ a: this.host.state.a + e.pageX });
-	this.host.setState({ b: this.host.state.b + e.pageY });
+function onEvt4$0(host, e) {
+	host.setState({ a: host.state.a + e.pageX });
+	host.setState({ b: host.state.b + e.pageY });
 }
 
 export default function template$0(host, scope) {

--- a/packages/template-compiler/test/fixtures/templates/events-loop.js
+++ b/packages/template-compiler/test/fixtures/templates/events-loop.js
@@ -1,4 +1,5 @@
 import { addEvent, appendChild, createInjector, elem, elemWithText, insert, mountIterator, removeEvent, unmountIterator, updateIterator } from "endorphin";
+import { handleClick } from "%definition";
 
 function setVars$0(host, scope) {
 	scope.foo = 1;
@@ -12,8 +13,8 @@ function setVars$1(host, scope) {
 	scope.bar = scope.foo;
 }
 
-function onClick$0(evt) {
-	this.host.componentModel.definition.handleClick(this.scope.index, this.scope.foo, this.scope.bar, this.host, evt, this.target);
+function onClick$0(host, evt, target, scope) {
+	handleClick(scope.index, scope.foo, scope.bar, host, evt, target);
 }
 
 function forContent$0(host, injector, scope) {

--- a/packages/template-compiler/test/fixtures/templates/events-loop.js
+++ b/packages/template-compiler/test/fixtures/templates/events-loop.js
@@ -1,5 +1,7 @@
 import { addEvent, appendChild, createInjector, elem, elemWithText, insert, mountIterator, removeEvent, unmountIterator, updateIterator } from "endorphin";
-import { handleClick } from "%definition";
+
+export function handleClick() {}
+
 
 function setVars$0(host, scope) {
 	scope.foo = 1;

--- a/packages/template-compiler/test/fixtures/templates/events.js
+++ b/packages/template-compiler/test/fixtures/templates/events.js
@@ -1,6 +1,10 @@
 import { addEvent, appendChild, detachPendingEvents, elem, finalizePendingEvents, pendingEvents, removeEvent, setPendingEvent } from "endorphin";
 import { emit } from "endorphin/helpers";
-import { method1, method2, onLeave } from "%definition";
+
+export function method1() {}
+export function method2() {}
+export function onLeave() {}
+
 
 function onClick$0(host, evt, target) {
 	method1(host.props.foo, host.props.bar, host, evt, target);

--- a/packages/template-compiler/test/fixtures/templates/events.js
+++ b/packages/template-compiler/test/fixtures/templates/events.js
@@ -1,33 +1,30 @@
-import { addEvent, appendChild, detachPendingEvents, elem, finalizePendingEvents, get, pendingEvents, removeEvent, setPendingEvent } from "endorphin";
+import { addEvent, appendChild, detachPendingEvents, elem, finalizePendingEvents, pendingEvents, removeEvent, setPendingEvent } from "endorphin";
 import { emit } from "endorphin/helpers";
+import { method1, method2, onLeave } from "%definition";
 
-function onClick$0(evt) {
-	this.host.componentModel.definition.method1(this.host.props.foo, this.host.props.bar, this.host, evt, this.target);
+function onClick$0(host, evt, target) {
+	method1(host.props.foo, host.props.bar, host, evt, target);
 }
 
-function onMouseenter$0() {
-	emit(this.host, "hover");
+function onMouseenter$0(host) {
+	emit(host, "hover");
 }
 
-function onMouseleave$0(evt) {
-	this.host.componentModel.definition.onLeave(this.host, evt, evt.currentTarget, this.host, evt, this.target);
-}
-
-function onKeypress$0(evt) {
+function onKeypress$0(host, evt) {
 	evt.stopPropagation();
 }
 
-function onMousedown$0(e) {
+function onMousedown$0(host, e) {
 	e.preventDefault();
-	emit(this.host, "down", get(e, "pageX"), get(e, "pageY"));
+	emit(host, "down", e.pageX, e.pageY);
 }
 
-function onEvent2$0() {
-	emit(this.host, "update", { [this.host.props.name]: !this.host.props.open, key: this.host.props.value });
+function onEvent2$0(host) {
+	emit(host, "update", { [host.props.name]: !host.props.open, key: host.props.value });
 }
 
-function onClick$1(evt) {
-	this.host.componentModel.definition.method2(this.host.props.foo, this.host.props.bar, this.host, evt, this.target);
+function onClick$1(host, evt, target) {
+	method2(host.props.foo, host.props.bar, host, evt, target);
 }
 
 function ifAttr$0(host, scope) {
@@ -42,7 +39,7 @@ export default function template$0(host, scope) {
 	const _e$0 = scope._e$0 = pendingEvents(host, main$0);
 	setPendingEvent(_e$0, "click", onClick$0, scope);
 	scope.mouseenter$0 = addEvent(main$0, "mouseenter", onMouseenter$0, host, scope);
-	scope.mouseleave$0 = addEvent(main$0, "mouseleave", onMouseleave$0, host, scope);
+	scope.mouseleave$0 = addEvent(main$0, "mouseleave", onLeave, host, scope);
 	scope.keypress$0 = addEvent(main$0, "keypress", onKeypress$0, host, scope);
 	scope.mousedown$0 = addEvent(main$0, "mousedown", onMousedown$0, host, scope);
 	scope.event2$0 = addEvent(main$0, "event2", onEvent2$0, host, scope);

--- a/packages/template-compiler/test/fixtures/templates/store.js
+++ b/packages/template-compiler/test/fixtures/templates/store.js
@@ -1,7 +1,7 @@
 import { addEvent, appendChild, call, elem, removeEvent, subscribeStore, text, updateText } from "endorphin";
 
-function onClick$0(evt) {
-	call(this.host.store, "update", [this.host.state.item]);
+function onClick$0(host, evt) {
+	call(host.store, "update", [host.state.item]);
 }
 
 export default function template$0(host, scope) {

--- a/packages/template-compiler/test/samples/templates/animate-function.html
+++ b/packages/template-compiler/test/samples/templates/animate-function.html
@@ -10,4 +10,7 @@
         <inner-component/>
     </outer-component>
 </template>
-
+<script>
+export function collapse() {};
+export function expand() {};
+</script>

--- a/packages/template-compiler/test/samples/templates/events-loop.html
+++ b/packages/template-compiler/test/samples/templates/events-loop.html
@@ -9,3 +9,6 @@
         <e:variable foo={2} />
     </ul>
 </template>
+<script>
+export function handleClick() {}
+</script>

--- a/packages/template-compiler/test/samples/templates/events.html
+++ b/packages/template-compiler/test/samples/templates/events.html
@@ -10,3 +10,8 @@
         <e:attribute on:click={method2(foo, bar)} e:if={c1} />
     </main>
 </template>
+<script>
+export function method1() {}
+export function method2() {}
+export function onLeave() {}
+</script>

--- a/packages/template-runtime/src/event.ts
+++ b/packages/template-runtime/src/event.ts
@@ -1,5 +1,5 @@
 import { runtimeError, obj } from './utils';
-import { Scope, EventBinding } from './types';
+import { Scope, EventBinding, ComponentEventListener } from './types';
 import { Component } from './component';
 
 interface PendingEvents {
@@ -12,7 +12,7 @@ interface PendingEvents {
  * Registers given event listener on `target` element and returns event binding
  * object to unregister event
  */
-export function addEvent(target: Element, type: string, listener: EventListener, host: Component, scope: Scope): EventBinding {
+export function addEvent(target: Element, type: string, listener: ComponentEventListener, host: Component, scope: Scope): EventBinding {
 	return registerBinding(type, { host, scope, target, listener, handleEvent });
 }
 
@@ -30,7 +30,7 @@ export function pendingEvents(host: Component, target: Element): PendingEvents {
 	return { host, target, events: obj() };
 }
 
-export function setPendingEvent(pending: PendingEvents, type: string, listener: EventListener, scope: Scope) {
+export function setPendingEvent(pending: PendingEvents, type: string, listener: ComponentEventListener, scope: Scope) {
 	let binding = pending.events[type];
 	if (binding) {
 		binding.listener = listener;
@@ -69,7 +69,7 @@ export function detachPendingEvents(pending: PendingEvents) {
 
 function handleEvent(this: EventBinding, event: Event) {
 	try {
-		this.listener && this.listener(event);
+		this.listener && this.listener(this.host, event, this.target, this.scope);
 	} catch (error) {
 		runtimeError(this.host, error);
 		// tslint:disable-next-line:no-console

--- a/packages/template-runtime/src/types.ts
+++ b/packages/template-runtime/src/types.ts
@@ -41,10 +41,12 @@ export type Changes<T = any> = {
 	}
 };
 
+export type ComponentEventListener = (host: Component, event: Event, target: Element, scope: Scope) => void;
+
 export interface EventBinding extends EventListenerObject {
 	host: Component;
 	scope: Scope;
 	target: Element;
-	listener?: EventListener;
-	pending?: EventListener;
+	listener?: ComponentEventListener;
+	pending?: ComponentEventListener;
 }

--- a/packages/template-runtime/test/event.ts
+++ b/packages/template-runtime/test/event.ts
@@ -1,43 +1,26 @@
 import { strictEqual, deepStrictEqual } from 'assert';
 import document, { ElementShim, EventShim } from './assets/document';
 import { createComponent, mountComponent, updateComponent } from '../src/runtime';
-import { Component } from '../src/component';
+import { calls, resetCalls } from './samples/scripts/events';
 
 // @ts-ignore
-import template from './samples/events.html';
+import * as Events from './samples/events.html';
 // @ts-ignore
-import loopTemplate from './samples/events-loop.html';
+import * as EventsLoop from './samples/events-loop.html';
 // @ts-ignore
-import branching from './samples/branching.html';
+import * as Branching from './samples/branching.html';
 
 describe('Event handler', () => {
 	before(() => global['document'] = document);
 	after(() => delete global['document']);
+	beforeEach(resetCalls);
 
 	function dispatch(node: Node, evt: EventShim) {
 		(node as any as ElementShim).dispatchEvent(evt);
 	}
 
 	it('should add and call event handler', () => {
-		const calls = {
-			method1: [],
-			method2: []
-		};
-
-		const component = createComponent('my-component', {
-			default: template,
-			props() {
-				return { foo: 'foo1', bar: 'bar2', c1: false };
-			},
-			method1(arg1: any, arg2: any, host: Component, evt: Event) {
-				strictEqual(evt.type, 'click');
-				calls.method1.push([arg1, arg2]);
-			},
-			method2(arg1: any, arg2: any, host: Component, evt: Event) {
-				strictEqual(evt.type, 'click');
-				calls.method2.push([arg1, arg2]);
-			}
-		});
+		const component = createComponent('my-component', Events);
 
 		// Initial render
 		mountComponent(component);
@@ -62,58 +45,36 @@ describe('Event handler', () => {
 	});
 
 	it('should add and call event handler in loops', () => {
-		const calls = [];
-
-		const component = createComponent('my-component', {
-			default: loopTemplate,
-			props() {
-				return {
-					items: [1, 2, 3]
-				};
-			},
-			handleClick(arg1: any, arg2: any, arg3: any, host: Component, evt: Event) {
-				strictEqual(evt.type, 'click');
-				calls.push([arg1, arg2, arg3]);
-			}
-		});
+		const component = createComponent('my-component', EventsLoop);
 
 		// Initial render
 		mountComponent(component);
 		dispatch(component.firstChild.childNodes[0], { type: 'click' });
 		dispatch(component.firstChild.childNodes[1], { type: 'click' });
 		strictEqual(component.innerHTML, '<ul>\n\t<li>item</li>\n\t<li>item</li>\n\t<li>item</li>\n</ul>');
-		deepStrictEqual(calls, [[0, 2, 1], [1, 2, 1]]);
+		deepStrictEqual(calls.handleClick, [[0, 2, 1], [1, 2, 1]]);
 
 		// Re-run template: nothing should change
 		updateComponent(component);
 		dispatch(component.firstChild.childNodes[0], { type: 'click' });
 		dispatch(component.firstChild.childNodes[1], { type: 'click' });
 		strictEqual(component.innerHTML, '<ul>\n\t<li>item</li>\n\t<li>item</li>\n\t<li>item</li>\n</ul>');
-		deepStrictEqual(calls, [[0, 2, 1], [1, 2, 1], [0, 2, 1], [1, 2, 1]]);
+		deepStrictEqual(calls.handleClick, [[0, 2, 1], [1, 2, 1], [0, 2, 1], [1, 2, 1]]);
 	});
 
 	it('should attach static events', () => {
-		let calls = 0;
-
-		const component = createComponent('my-component', {
-			default: branching,
-			events: {
-				click() {
-					calls++;
-				}
-			}
-		});
+		const component = createComponent('my-component', Branching);
 
 		// Initial render
 		mountComponent(component);
 		dispatch(component.firstChild.childNodes[0], { type: 'click' });
 
 		// Event should bubble up to container
-		strictEqual(calls, 1);
+		strictEqual(calls.staticClick, 1);
 
 		// Re-run template: nothing should change
 		updateComponent(component);
 		dispatch(component.firstChild.childNodes[0], { type: 'click' });
-		strictEqual(calls, 2);
+		strictEqual(calls.staticClick, 2);
 	});
 });

--- a/packages/template-runtime/test/samples/branching.html
+++ b/packages/template-runtime/test/samples/branching.html
@@ -24,3 +24,4 @@
 		<p>Lorem ipsum 2</p>
 	</blockquote>
 </template>
+<script src="./scripts/events.js"></script>

--- a/packages/template-runtime/test/samples/events-loop.html
+++ b/packages/template-runtime/test/samples/events-loop.html
@@ -9,3 +9,4 @@
 		<e:variable foo={2} />
 	</ul>
 </template>
+<script src="./scripts/events.js"></script>

--- a/packages/template-runtime/test/samples/events.html
+++ b/packages/template-runtime/test/samples/events.html
@@ -4,3 +4,4 @@
 		<e:attribute on:click={method2(foo, bar)} e:if={c1} />
 	</main>
 </template>
+<script src="./scripts/events.js"></script>

--- a/packages/template-runtime/test/samples/scripts/events.js
+++ b/packages/template-runtime/test/samples/scripts/events.js
@@ -1,0 +1,42 @@
+import { strictEqual } from 'assert';
+
+export const calls = {
+    method1: [],
+    method2: [],
+    handleClick: [],
+    staticClick: 0
+};
+
+export const events = {
+    click() {
+        calls.staticClick++;
+    }
+};
+
+export function resetCalls() {
+    calls.method1.length = calls.method2.length = calls.handleClick.length = calls.staticClick = 0;
+}
+
+export function props() {
+    return {
+        foo: 'foo1',
+        bar: 'bar2',
+        c1: false,
+        items: [1, 2, 3]
+    };
+}
+
+export function method1(arg1, arg2, host, evt) {
+    strictEqual(evt.type, 'click');
+    calls.method1.push([arg1, arg2]);
+}
+
+export function method2(arg1, arg2, host, evt) {
+    strictEqual(evt.type, 'click');
+    calls.method2.push([arg1, arg2]);
+}
+
+export function handleClick(arg1, arg2, arg3, host, evt) {
+    strictEqual(evt.type, 'click');
+    calls.handleClick.push([arg1, arg2, arg3]);
+}

--- a/packages/template-runtime/test/samples/set1/my-component.html
+++ b/packages/template-runtime/test/samples/set1/my-component.html
@@ -10,17 +10,4 @@
 	</sub-component1>
 </template>
 
-<script>
-import { Store } from '../../../src/runtime';
-
-export function store() {
-	return new Store({ foo: 'bar' });
-}
-
-export function props() {
-	return {
-		value1: 1,
-		value2: 2
-	};
-}
-</script>
+<script src="./my-component.js"></script>

--- a/packages/template-runtime/test/samples/set1/my-component.js
+++ b/packages/template-runtime/test/samples/set1/my-component.js
@@ -1,0 +1,12 @@
+import { Store } from '../../../src/runtime';
+
+export function store() {
+    return new Store({ foo: 'bar' });
+}
+
+export function props() {
+    return {
+        value1: 1,
+        value2: 2
+    };
+}

--- a/packages/template-runtime/test/samples/slots/inner-component.html
+++ b/packages/template-runtime/test/samples/slots/inner-component.html
@@ -4,8 +4,4 @@
 	<slot name="footer">Default footer</slot>
 </template>
 
-<script>
-export function didSlotUpdate(component, slotName, slotBody) {
-	global.slotCallbacks.push([slotName, slotBody.textContent.trim()]);
-}
-</script>
+<script src="./inner-component.js"></script>

--- a/packages/template-runtime/test/samples/slots/inner-component.js
+++ b/packages/template-runtime/test/samples/slots/inner-component.js
@@ -1,0 +1,9 @@
+export const slotCallbacks = [];
+
+export function resetCallbacks() {
+	slotCallbacks.length = 0;
+}
+
+export function didSlotUpdate(component, slotName, slotBody) {
+	slotCallbacks.push([slotName, slotBody.textContent.trim()]);
+}

--- a/packages/template-runtime/test/slot-update-hook.ts
+++ b/packages/template-runtime/test/slot-update-hook.ts
@@ -1,6 +1,7 @@
 import { strictEqual, deepStrictEqual } from 'assert';
 import document from './assets/document';
 import { createComponent, mountComponent } from '../src/runtime';
+import { slotCallbacks, resetCallbacks } from './samples/slots/inner-component';
 
 // @ts-ignore
 import sample1 from './samples/slots/outer-component1.html';
@@ -10,18 +11,11 @@ import sample2 from './samples/slots/outer-component2.html';
 import sample3 from './samples/slots/outer-component3.html';
 
 describe('Slot Update Hook', () => {
-	const slotCallbacks = [];
 	const last = (arr: any[]) => arr[arr.length - 1];
 
-	before(() => {
-		global['document'] = document;
-		global['slotCallbacks'] = slotCallbacks;
-	});
-	after(() => {
-		delete global['document'];
-		delete global['slotCallbacks'];
-	});
-	afterEach(() => slotCallbacks.length = 0);
+	before(() => global['document'] = document);
+	after(() => delete global['document']);
+	beforeEach(resetCallbacks);
 
 	it('sample 1', () => {
 		const component = createComponent('my-component', {


### PR DESCRIPTION
This PR imports JS symbols used by template (event handlers, transitions) from JS definition module instead of referencing it by `host.componentModel.definition` which outputs much smaller event handler code.