### PR TITLE
Support node.js 18+

### DIFF
--- a/packages/template-compiler/package.json
+++ b/packages/template-compiler/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@endorphinjs/template-parser": "^0.10.0",
     "entities": "^1.1.2",
-    "source-map": "0.8.0-beta.0"
+    "source-map": "0.7.4"
   },
   "directories": {
     "test": "test"

--- a/packages/template-compiler/package.json
+++ b/packages/template-compiler/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@endorphinjs/template-parser": "^0.10.0",
     "entities": "^1.1.2",
-    "source-map": "^0.7.3"
+    "source-map": "0.8.0-beta.0"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
It would be great if endorphin supports Node.js 18+. Now we have blocker which is `source-map` dependency. Current version of `source-map` relies on naive checking of global `fetch` [(more detail)](https://github.com/terser/terser/pull/1164).
So it causes error when trying to build project using endorphin.
```
Error: You must provide the URL of lib/mappings.wasm by calling SourceMapConsumer.initialize({ 'lib/mappings.wasm': ... }) before using SourceMapConsumer
```

Unfortunately, this solution involves using beta version, but I hope it will stable soon.